### PR TITLE
Support GitHub enterprise with `--url` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Flags:
 
 Use "github-app-token-generator-cli [command] --help" for more information about a command.
 ```
+
+## GitHub Enterprise
+
+For users using GitHub enterprise, you can specify the GitHub API's URL with `--url` flag as below:
+
+```console
+$ github-app-token-generator-cli xxx yyy private-key.pem  --url https://<YOUR_HOST>/api/v3
+```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Flags:
       --request-timeout string   timeout for each request (default "30s")
   -r, --retry int                retry count (default 5)
   -t, --timeout string           overall timeout (default "1s")
+      --url                      url of the GitHub API
 
 Use "github-app-token-generator-cli [command] --help" for more information about a command.
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,9 @@ type rootOpt struct {
 
 	logFormat string
 	logLevel  string
+
+	// For enterprise users
+	url string
 }
 
 func newRootCmd(out io.Writer) *cobra.Command {
@@ -63,6 +66,7 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.reqTimeout, "request-timeout", "30s", "timeout for each request")
 	cmd.PersistentFlags().StringVarP(&opts.logFormat, "log-format", "", "console", "format of the logs")
 	cmd.PersistentFlags().StringVarP(&opts.logLevel, "log-level", "", "info", "output of the logs")
+	cmd.PersistentFlags().StringVar(&opts.url, "url", "", "url of the GitHub API. Defaults to the https://api.github.com")
 
 	return cmd
 }
@@ -107,6 +111,9 @@ func run(out io.Writer, opts *rootOpt) func(cmd *cobra.Command, args []string) e
 			appInstallationID,
 			rsaPrivateKeyPemPath,
 		)
+		if opts.url != "" {
+			itr.BaseURL = opts.url
+		}
 
 		if err != nil {
 			log.Fatal("Failed to create new transport", zap.Error(err))


### PR DESCRIPTION
## WHY

Because this CLI can be used for enterprise GitHub apps too.